### PR TITLE
Update docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ We recommend installing the Spotlight dashboard as a Docker instance on the targ
 
 ***Remember to add your own `SECRET_KEY_BASE`.***
 
+### Initial setup
+
+1. Run this command to prepare the db:
+
+	```
+	docker-compose run --rm api rake db:create db:migrate
+	```
+	
 ### Starting the Spotlight Docker instance
 
 1. Run the following command:
 
 	```
-	docker-compose run --rm api rake db:create db:migrate
 	docker-compose up -d
 	```
 
@@ -100,35 +107,35 @@ To contribute code to this project, you will need to setup your local developmen
 2. Install [rbenv](https://github.com/rbenv/rbenv):
 
 	```
-brew update
-brew install rbenv ruby-build
-```
+	brew update
+	brew install rbenv ruby-build
+	```
 
 3. Add `rbenv` support to your local profile:
 
 	```
-echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
-echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
-```
+	echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
+	echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+	```
 
 	If you are using `zsh`:
 
 	```
-echo 'eval "$(rbenv init -)"' >> ~/.zshrc
-```
+	echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+	```
 
 3. Install the current Ruby version:
 
 	```
-rbenv install -l
-rbenv install 2.3.0
-```
+	rbenv install -l
+	rbenv install 2.3.0
+	```
 
 4. Use it globally:
 
 	```
-rbenv global 2.3.0
-```
+	rbenv global 2.3.0
+	```
 
 ### B. Install PostgreSQL database server
 
@@ -141,48 +148,48 @@ rbenv global 2.3.0
 1. Install [Bundler](http://bundler.io/), the Ruby dependency management software:
 
 	```
-gem install bundler
-```
+	gem install bundler
+	```
 
 2. Install the rest of the Ruby Gems needed for the app (including Ruby on Rails):
 
 	```
-bundle install
-```
+	bundle install
+	```
 
 ### D. Prepare the Database
 
 1. Create the database:
 
 	```
-bundle exec rake db:create
-```
+	bundle exec rake db:create
+	```
 
 2. Create the database tables:
 
 	```
-bundle exec rake db:migrate
-```
+	bundle exec rake db:migrate
+	```
 
 3. Prepare sample data:
 
 	```
-bundle exec rake db:seed
-```
+	bundle exec rake db:seed
+	```
 
 ### E. Start the development web server
 
 1. Prepare the environment file (one time exercise):
 
-  ```
-cp env.sample .env
-```
+ 	```
+	cp env.sample .env
+	```
 
 2. You can start the local development web server with the following command:
 
 	```
-foreman start
-```
+	foreman start
+	```
 
 3. You can now visit the local development site at [http://localhost:3000](http://localhost:3000).
 
@@ -214,37 +221,37 @@ or open your browser to [http://localhost:3000/specs](http://localhost:3000/spec
 1. Rebuild the local Docker image
 
 	```
-docker build -t spotlight-rails .
-```
+	docker build -t spotlight-rails .
+	```
 
 2. Check for the image ID
 
 	```
-➜  spotlight git:(docker) ✗ docker images
-REPOSITORY                       TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-spotlight-rails                  latest              ba3dcc9b42b1        16 seconds ago      954.3 MB
-```
+	➜  spotlight git:(docker) ✗ docker images
+	REPOSITORY                       TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+	spotlight-rails                  latest              ba3dcc9b42b1        16 seconds ago      954.3 MB
+	```
 
 3. Login to your Docker account (one time exercise) with `docker login`:
 
 	```
-➜  spotlight git:(docker) ✗ docker login
-Username (miccheng):
-WARNING: login credentials saved in /Users/miccheng/.docker/config.json
-Login Succeeded
-```
+	➜  spotlight git:(docker) ✗ docker login
+	Username (miccheng):
+	WARNING: login credentials saved in /Users/miccheng/.docker/config.json
+	Login Succeeded
+	```
 
 4. Tag the image (assuming `ba3dcc9b42b1` is the latest image ID)
 
 	```
-docker tag ba3dcc9b42b1 pivotalsingapore/spotlight-rails:latest
-```
+	docker tag ba3dcc9b42b1 pivotalsingapore/spotlight-rails:latest
+	```
 
 5. Push to Docker Hub
 
 	```
-docker push pivotalsingapore/spotlight-rails
-```
+	docker push pivotalsingapore/spotlight-rails
+	```
 
 ## Running in Concourse
 

--- a/README.md
+++ b/README.md
@@ -33,36 +33,42 @@ We recommend installing the Spotlight dashboard as a Docker instance on the targ
 
 2. In your working folder, create a new file: `docker-compose.yml`
 
+    ```yaml
+db:
+  image: postgres
+api:
+  image: pivotalsingapore/spotlight-rails
+  command: bin/rails server
+  env_file: docker_env
+  links:
+    - db
+web:
+  image: pivotalsingapore/spotlight-dashboard
+  env_file: docker_env
+  ports:
+    - "3030:80"
+  links:
+    - api
+  ```
+
+3. Rename `docker_env.sample` to `docker_env` and edit your configuration as necessary:
+
 	```yaml
-	db:
-	  image: postgres
-	api:
-	  image: pivotalsingapore/spotlight-rails
-	  command: bundle exec foreman start
-	  environment:
-	    - SECRET_KEY_BASE=<change_me!>
-	    - WEB_HOST=/
-	    - GOOGLE_API_CLIENT_ID=<change_me!>
-	    - GOOGLE_API_CLIENT_SECRET=<change_me!>
-	  links:
-	    - db
-	web:
-	  image: pivotalsingapore/spotlight-dashboard
-	  ports:
-	    - "3030:80"
-	  links:
-	    - api
+SECRET_KEY_BASE=<change_me!>
+WEB_HOST=/
+GOOGLE_API_CLIENT_ID=<change_me!>
+GOOGLE_API_CLIENT_SECRET=<change_me!>
 ```
 
-	***Remember to add your own `SECRET_KEY_BASE`.***
+***Remember to add your own `SECRET_KEY_BASE`.***
 
 ### Starting the Spotlight Docker instance
 
 1. Run the following command:
 
 	```
+docker-compose run --rm api rake db:create db:migrate
 docker-compose up -d
-docker-compose run --rm web rake db:create db:migrate
 ```
 
 2. You can now access the dashboard via the container IP address (e.g. `http://192.168.99.100:3030`).

--- a/README.md
+++ b/README.md
@@ -34,31 +34,31 @@ We recommend installing the Spotlight dashboard as a Docker instance on the targ
 2. In your working folder, create a new file: `docker-compose.yml`
 
     ```yaml
-db:
-  image: postgres
-api:
-  image: pivotalsingapore/spotlight-rails
-  command: bin/rails server
-  env_file: docker_env
-  links:
-    - db
-web:
-  image: pivotalsingapore/spotlight-dashboard
-  env_file: docker_env
-  ports:
-    - "3030:80"
-  links:
-    - api
-  ```
+	db:
+	  image: postgres
+	api:
+	  image: pivotalsingapore/spotlight-rails
+	  command: bin/rails server
+	  env_file: docker_env
+	  links:
+	    - db
+	web:
+	  image: pivotalsingapore/spotlight-dashboard
+	  env_file: docker_env
+	  ports:
+	    - "3030:80"
+	  links:
+	    - api
+	```
 
 3. Rename `docker_env.sample` to `docker_env` and edit your configuration as necessary:
 
 	```yaml
-SECRET_KEY_BASE=<change_me!>
-WEB_HOST=/
-GOOGLE_API_CLIENT_ID=<change_me!>
-GOOGLE_API_CLIENT_SECRET=<change_me!>
-```
+	SECRET_KEY_BASE=<change_me!>
+	WEB_HOST=/
+	GOOGLE_API_CLIENT_ID=<change_me!>
+	GOOGLE_API_CLIENT_SECRET=<change_me!>
+	```
 
 ***Remember to add your own `SECRET_KEY_BASE`.***
 
@@ -67,9 +67,9 @@ GOOGLE_API_CLIENT_SECRET=<change_me!>
 1. Run the following command:
 
 	```
-docker-compose run --rm api rake db:create db:migrate
-docker-compose up -d
-```
+	docker-compose run --rm api rake db:create db:migrate
+	docker-compose up -d
+	```
 
 2. You can now access the dashboard via the container IP address (e.g. `http://192.168.99.100:3030`).
 


### PR DESCRIPTION
## Issue: 
First of all, thanks for spotlight! It is indeed a great tool for our office. 

However, in the process of setting up, we ran into some docker issues due to outdated documentation in the `README`, but we managed to figure out the proper commands and get it running. So I figured others might find it useful to have proper instructions too.

## Fix: Updated docker instructions.

The `docker` instructions in the README is broken and the docker image will fail to start, because of this line:

`docker-compose run --rm web rake db:create db:migrate`

the command above will fail. It should instead be:

`docker-compose run --rm api rake db:create db:migrate`

as the migrations should be run against `api`, not `web`.

I've also updated the `docker-compose.yml` file to reflect the changes to the file:

[x] change `environment` to `env_file`
[x] add `docker_env` instructions